### PR TITLE
standard logging and airflow logging

### DIFF
--- a/src/etl_rest_to_postgres/extract.py
+++ b/src/etl_rest_to_postgres/extract.py
@@ -7,9 +7,9 @@
 
 from utils.file_handler import save_raw_data
 from utils.api_requests import fetch_data
-from utils.logging_config import get_logger
+import logging
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 def extract_data(config):
     """

--- a/src/etl_rest_to_postgres/postgres_loader.py
+++ b/src/etl_rest_to_postgres/postgres_loader.py
@@ -10,9 +10,9 @@ import json
 from datetime import datetime
 from utils.schema import IntradayData
 from utils.db_connection import get_db_session
-from utils.logging_config import get_logger
+import logging
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 def load_data(processed_file_path: str, config: dict) -> int:
     try:

--- a/src/etl_rest_to_postgres/transform.py
+++ b/src/etl_rest_to_postgres/transform.py
@@ -11,12 +11,11 @@ from datetime import datetime
 from threading import Lock
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
-
 from utils.file_handler import save_processed_data
 from utils.data_validation import transform_and_validate_data
-from utils.logging_config import get_logger
+import logging
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 def load_raw_data(raw_file_path: str) -> Optional[dict]:
     if not os.path.exists(raw_file_path):


### PR DESCRIPTION
- use standard logging in DAG's and DAG script(s) to allow airflow logging to take over.
- logging.py should only be used for scripts outside airflow/docker logging. 